### PR TITLE
feature - announceFirstBlood: 로직 구현 완료

### DIFF
--- a/app/src/main/java/com/example/villageofcyber/core/application/AppApplication.kt
+++ b/app/src/main/java/com/example/villageofcyber/core/application/AppApplication.kt
@@ -3,6 +3,7 @@ package com.example.villageofcyber.core.application
 import android.app.Application
 import com.example.villageofcyber.inGame.data.dataSource.CharacterDataSrouceImpl
 import com.example.villageofcyber.inGame.data.repository.CharacterRepositoryImpl
+import com.example.villageofcyber.inGame.domain.useCase.GetCharacterWhoHasFirstBloodUseCase
 import com.example.villageofcyber.inGame.domain.useCase.GetCharacterMiniFacesUseCase
 
 class AppApplication: Application() {
@@ -13,4 +14,5 @@ class AppApplication: Application() {
     val characterDataSource by lazy { CharacterDataSrouceImpl() }
     val characterRepository by lazy { CharacterRepositoryImpl(characterDataSource) }
     val getCharacterMiniFacesUseCase by lazy { GetCharacterMiniFacesUseCase() }
+    val getCharacterWhoHasFirstBloodUseCase by lazy { GetCharacterWhoHasFirstBloodUseCase() }
 }

--- a/app/src/main/java/com/example/villageofcyber/inGame/domain/useCase/GetCharacterWhoHasFirstBloodUseCase.kt
+++ b/app/src/main/java/com/example/villageofcyber/inGame/domain/useCase/GetCharacterWhoHasFirstBloodUseCase.kt
@@ -1,0 +1,15 @@
+package com.example.villageofcyber.inGame.domain.useCase
+
+import com.example.villageofcyber.inGame.domain.modelClass.Character
+import com.example.villageofcyber.inGame.domain.modelClass.Role
+
+class GetCharacterWhoHasFirstBloodUseCase() {
+    fun execute(characters: List<Character>): Character {
+        characters.forEach { character ->
+            if(character.role == Role.FIRSTBLOOD) {
+                return character
+            }
+        }
+        throw Exception("there is no character who has FirstBlood")
+    }
+}

--- a/app/src/main/java/com/example/villageofcyber/inGame/presentation/component/SpeakingSpot.kt
+++ b/app/src/main/java/com/example/villageofcyber/inGame/presentation/component/SpeakingSpot.kt
@@ -1,6 +1,7 @@
 package com.example.villageofcyber.inGame.presentation.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -24,6 +25,7 @@ fun SpeakingSpot(
     modifier: Modifier = Modifier,
     who: Int,
     message: String = "",
+    onClick: () -> Unit = {}
 ) {
     Box(    // 터치 이벤트를 가로채기 위함.
         modifier = Modifier
@@ -51,7 +53,10 @@ fun SpeakingSpot(
                 )
                 SpeechPanel(
                     modifier = Modifier
-                        .height(maxHeight * 0.3f),
+                        .height(maxHeight * 0.3f)
+                        .clickable {
+                            onClick()
+                        },
                     message = message
                 )
             }

--- a/app/src/main/java/com/example/villageofcyber/inGame/presentation/screen/InGameScreen.kt
+++ b/app/src/main/java/com/example/villageofcyber/inGame/presentation/screen/InGameScreen.kt
@@ -40,7 +40,8 @@ fun InGameScreen(
     onAction: (InGameAction) -> Unit = {}
 ) {
     if(state.dayStart) {
-        onAction(InGameAction.operateBlackPanel)
+        onAction(InGameAction.OperateBlackPanel)
+        onAction(InGameAction.AnnounceFirstBlood)
     }
 
     Box(
@@ -126,16 +127,19 @@ fun InGameScreen(
                 modifier = Modifier
                     .width(350.dp)
                     .height(400.dp),
-                who = R.drawable.brothel,
-                message = "살려주세요."
+                who = state.characterFaceWhoIsSpeaking ?: throw Exception("from InGameScreen. there is no person on speaking spot"),
+                message = state.messageFromSpeaker,
+                onClick = {
+                    onAction(InGameAction.OnClickNextSpeaking)
+                }
             )
         }
     }
-//    BlackPanel(
-//        modifier = Modifier
-//            .fillMaxSize()
-//            .alpha(state.transparencyOfBlackPanel)
-//    )
+    BlackPanel(
+        modifier = Modifier
+            .fillMaxSize()
+            .alpha(state.transparencyOfBlackPanel)
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/example/villageofcyber/inGame/presentation/viewModel/InGameAction.kt
+++ b/app/src/main/java/com/example/villageofcyber/inGame/presentation/viewModel/InGameAction.kt
@@ -3,5 +3,7 @@ package com.example.villageofcyber.inGame.presentation.viewModel
 sealed interface InGameAction {
     data object OnClickOpenCommandMenu: InGameAction
     data object OnClickCloseCommandMenu: InGameAction
-    data object operateBlackPanel: InGameAction
+    data object OperateBlackPanel: InGameAction
+    data object OnClickNextSpeaking: InGameAction
+    data object AnnounceFirstBlood: InGameAction
 }

--- a/app/src/main/java/com/example/villageofcyber/inGame/presentation/viewModel/InGameState.kt
+++ b/app/src/main/java/com/example/villageofcyber/inGame/presentation/viewModel/InGameState.kt
@@ -17,5 +17,9 @@ data class InGameState(
 
     val prophetRoleHistory: Map<Character, List<Character>> = emptyMap(),
     val traitorRoleHistory: Map<Character, List<Character>> = emptyMap(),
-    val hunterRoleHistory: Map<Character, List<Character>> = emptyMap()
+    val hunterRoleHistory: Map<Character, List<Character>> = emptyMap(),
+
+    val characterFaceWhoIsSpeaking: Int? = null,
+    val messageFromSpeaker: String = "",
+    val nextMessage: Boolean = false
 )


### PR DESCRIPTION
# 요약
- 첫날 아침 초기 사망자 공지 시스템 구현 완료

# 설명
## getCharacterWhoHasFirstBloodUseCase 추가
- 초기 사망자를 찾아 캐릭터를 반환
## SpeakingSpot 컴포넌트
- 터치 시 알려주는 빈 콜백 연결
## InGameScreen
- 하드 코딩된 매개변수들 State로 연결
## InGameAction
- OnClickNextSpeaking: SpeakingSpot의 메시지 창 터치 시 Action
- AnnounceFirstBlood: 초기 사망자 공지 타이밍을 제공
## InGameState
- SpeakingSpot 컴포넌트에 전달해 줄 데이터들 추가
## InGameViewModel
- 초기 사망 공지 관련 로직 구현